### PR TITLE
adding key pair creation automation capability

### DIFF
--- a/ec2.tf
+++ b/ec2.tf
@@ -1,10 +1,11 @@
-resource "aws_instance" "ec2" {
-  count         = var.instance_count
+resource "aws_instance" "ec2_instance" {
   ami           = var.ami_id
   instance_type = var.instance_type
-  key_name      = var.key_name
+  count         = var.instance_count
 
-  tags = merge(var.tags, {
-    Name = "EC2-Instance-${count.index + 1}"
-  })
+  key_name = aws_key_pair.ec2_key_pair.key_name
+
+  tags = {
+    Name = "${var.instance_name}-${count.index}"
+  }
 }

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,11 @@
 module "ec2_instance" {
   source = "./"
 }
+
+
+# Key Pair Resource
+resource "aws_key_pair" "ec2_key_pair" {
+  key_name   = "my-ec2-key"
+  public_key = file(var.public_key_path)
+}
+

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,9 +1,9 @@
-output "instance_ids" {
-  description = "The IDs of the created EC2 instances."
-  value       = aws_instance.ec2[*].id
+output "instance_public_ips" {
+  description = "Public IPs of the EC2 instances"
+  value       = aws_instance.ec2_instance.*.public_ip
 }
 
-output "instance_public_ips" {
-  description = "The public IPs of the created EC2 instances."
-  value       = aws_instance.ec2[*].public_ip
+output "instance_ids" {
+  description = "IDs of the EC2 instances"
+  value       = aws_instance.ec2_instance.*.id
 }

--- a/terraform.tfvars
+++ b/terraform.tfvars
@@ -1,8 +1,10 @@
-region         = "us-west-2"    #enter a region you want the instance to be deployed in
-instance_type  = "t3.medium"    #enter an instance type to be dployed
-instance_count = 2              #specify the number of instances you want deployed.
-ami_id         = "ami-0abcdef1234567890" #Replace your ami id
-key_name       = "my-key-pair" #enter a name for your key pair
+region          = "us-east-1" #enter a region you want the instance to be deployed in
+ami_id          = "ami-0abcdef1234567890" #Replace your ami id
+instance_type   = "t2.micro" #enter an instance type to be dployed
+instance_count  = 2 #specify the number of instances you want deployed.
+instance_name   = "example-ec2-instance" #specify a name for the instance
+public_key_path = "~/.ssh/id_rsa.pub"
+#key_name       = "my-key-pair" #your-existing-key-pair-name
 tags = {
   Environment = "Production"    #enter a name for your environment
   Owner       = "EnterYourName" #enter an owner name tag

--- a/variables.tf
+++ b/variables.tf
@@ -1,37 +1,35 @@
 variable "region" {
-  description = "The AWS region to deploy resources in."
+  description = "AWS region to deploy resources"
   type        = string
   default     = "us-east-1"
 }
 
+variable "ami_id" {
+  description = "The AMI ID for the EC2 instance"
+  type        = string
+  default     = "ami-0abcdef1234567890"
+}
+
 variable "instance_type" {
-  description = "The type of EC2 instance."
+  description = "Instance type for the EC2 instance"
   type        = string
   default     = "t2.micro"
 }
 
 variable "instance_count" {
-  description = "Number of EC2 instances to create."
+  description = "Number of EC2 instances to launch"
   type        = number
   default     = 1
 }
 
-variable "ami_id" {
-  description = "The AMI ID for the EC2 instance."
+variable "instance_name" {
+  description = "Base name for EC2 instances"
   type        = string
-  default     = "ami-12345678"
+  default     = "my-ec2-instance"
 }
 
-variable "key_name" {
-  description = "The key pair name to use for SSH access."
+variable "public_key_path" {
+  description = "Path to the public SSH key"
   type        = string
-}
-
-variable "tags" {
-  description = "Tags to apply to the EC2 instances."
-  type        = map(string)
-  default     = {
-    Environment = "Development"
-    Owner       = "Admin"
-  }
+  default     = "~/.ssh/id_rsa.pub"
 }


### PR DESCRIPTION
This commit is an update to the code to enable adding key pair creation automation capability. With the previous version, the assumption was that you had an existing key pair and therefore you needed to add it